### PR TITLE
Fix MacOS Dist

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -194,13 +194,14 @@ tasks:
     desc: Builds Mac OS X 64 bit binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         mkdir {{.PLATFORM_DIR}}
         cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
@@ -218,13 +219,14 @@ tasks:
     desc: Builds Mac OS X ARM64 binaries
     dir: "{{.DIST_DIR}}"
     cmds:
+      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
       - |
         mkdir {{.PLATFORM_DIR}}
         cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
+        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
         tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}


### PR DESCRIPTION
We're using a container to compile for mac and apparently there is the following problem:
"git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232

