### PR TITLE
Expose armv7 build in the package_index.json

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -253,6 +253,8 @@ tasks:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_64bit.tar.gz | cut -f1 -d " "
       LINUXARM_SHA:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv6.tar.gz | cut -f1 -d " "
+      LINUXARMV7_SHA:
+        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv7.tar.gz | cut -f1 -d " "
       LINUXARM64_SHA:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARM64.tar.gz | cut -f1 -d " "
       OSX64_SHA:
@@ -269,6 +271,8 @@ tasks:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_64bit.tar.gz | cut -f5 -d " "
       LINUXARM_SIZE:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv6.tar.gz | cut -f5 -d " "
+      LINUXARMV7_SIZE:
+        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv7.tar.gz | cut -f5 -d " "
       LINUXARM64_SIZE:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARM64.tar.gz | cut -f5 -d " "
       OSX64_SIZE:
@@ -286,6 +290,8 @@ tasks:
         sed "s/%%LINUX32_SIZE%%/{{ .LINUX32_SIZE }}/" |
         sed "s/%%LINUXARM_SHA%%/{{ .LINUXARM_SHA }}/" |
         sed "s/%%LINUXARM_SIZE%%/{{ .LINUXARM_SIZE }}/" |
+        sed "s/%%LINUXARMV7_SHA%%/{{ .LINUXARMV7_SHA }}/" |
+        sed "s/%%LINUXARMV7_SIZE%%/{{ .LINUXARMV7_SIZE }}/" |
         sed "s/%%LINUXARM64_SHA%%/{{ .LINUXARM64_SHA }}/" |
         sed "s/%%LINUXARM64_SIZE%%/{{ .LINUXARM64_SIZE }}/" |
         sed "s/%%OSX64_SHA%%/{{ .OSX64_SHA }}/" |

--- a/extras/package_index.json.template
+++ b/extras/package_index.json.template
@@ -52,6 +52,13 @@
               "size": "%%LINUXARM_SIZE%%"
             },
             {
+              "host": "arm-linux-gnueabihf",
+              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/%%FILENAME%%_%%VERSION%%_Linux_ARMv7.tar.gz",
+              "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_ARMv7.tar.gz",
+              "checksum": "SHA-256:%%LINUXARM_SHA%%",
+              "size": "%%LINUXARM_SIZE%%"
+            },
+            {
               "host": "aarch64-linux-gnu",
               "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/%%FILENAME%%_%%VERSION%%_Linux_ARM64.tar.gz",
               "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_ARM64.tar.gz",


### PR DESCRIPTION
We're building for armv7 but we're not publishing that in our package_index.json.

The uno r4 plugin is built with CGO, not publishing the armv7 binary will fallback on the armv6 one which won't run even on armv7 due to dynamically linked stuff.

To allow fw-uploader to take armv7 builds we have to give a unique name in the `host` key in the package_json template and handle such cases in:  https://github.com/arduino/arduino-cli/blob/df12786440c1078957734aa1686a38c86afcda84/arduino/cores/tools.go#L151