### PR TITLE
Add CI workflow to validate GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-workflows-task.yml
+++ b/.github/workflows/check-workflows-task.yml
@@ -1,0 +1,50 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-workflows-task.md
+name: Check Workflows
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 16.x
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "package.json"
+      - "package-lock.json"
+      - "Taskfile.ya?ml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.ya?ml"
+      - "package.json"
+      - "package-lock.json"
+      - "Taskfile.ya?ml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate workflows
+        run: task --silent ci:validate

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Check Markdown status](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-markdown-task.yml/badge.svg)](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-markdown-task.yml)
 [![Check License status](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-license.yml)
 [![Check Taskfiles status](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-taskfiles.yml)
+[![Check Workflows status](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/actions/workflows/check-workflows-task.yml)
 [![Codecov](https://codecov.io/gh/arduino/uno-r4-wifi-fwuploader-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/arduino/uno-r4-wifi-fwuploader-plugin)
 
 Be sure to have `libudev-dev` installed

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,6 +18,34 @@ tasks:
       - task: config:check
       - task: general:check-formatting
 
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
+  ci:validate:
+    desc: Validate GitHub Actions workflows against their JSON schema
+    vars:
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
+      WORKFLOW_SCHEMA_URL: https://json.schemastore.org/github-workflow
+      WORKFLOW_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="workflow-schema-XXXXXXXXXX.json"
+      WORKFLOWS_DATA_PATH: "./.github/workflows/*.{yml,yaml}"
+    deps:
+      - task: npm:install-deps
+    cmds:
+      - |
+        wget \
+          --quiet \
+          --output-document="{{.WORKFLOW_SCHEMA_PATH}}" \
+          {{.WORKFLOW_SCHEMA_URL}}
+      - |
+        npx \
+          --package=ajv-cli \
+          --package=ajv-formats \
+          ajv validate \
+            --all-errors \
+            --strict=false \
+            -c ajv-formats \
+            -s "{{.WORKFLOW_SCHEMA_PATH}}" \
+            -d "{{.WORKFLOWS_DATA_PATH}}"
+
   docs:generate:
     desc: Create all generated documentation content
     # This is an "umbrella" task used to call any documentation generation processes the project has.
@@ -205,6 +233,41 @@ tasks:
     cmds:
       - task: test-unit
       - task: go:test-integration
+
+  # Make a temporary file named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-file:
+    vars:
+      RAW_PATH:
+        sh: mktemp --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
+  # Make a temporary folder named according to the passed TEMPLATE variable and print the path passed to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:mktemp-folder:
+    vars:
+      RAW_PATH:
+        sh: mktemp --directory --tmpdir "{{.TEMPLATE}}"
+    cmds:
+      - task: utility:normalize-path
+        vars:
+          RAW_PATH: "{{.RAW_PATH}}"
+
+  # Print a normalized version of the path passed via the RAW_PATH variable to stdout
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/windows-task/Taskfile.yml
+  utility:normalize-path:
+    cmds:
+      - |
+        if [[ "{{.OS}}" == "Windows_NT" ]] && which cygpath &>/dev/null; then
+            # Even though the shell handles POSIX format absolute paths as expected, external applications do not.
+            # So paths passed to such applications must first be converted to Windows format.
+            cygpath -w "{{.RAW_PATH}}"
+        else
+          echo "{{.RAW_PATH}}"
+        fi
 
 vars:
   PROJECT_NAME: "uno-r4-wifi-fwuploader-plugin"


### PR DESCRIPTION
On every push or pull request that affects the repository's GitHub Actions workflows, and periodically, validate them against the JSON schema.