### PR TITLE
Change the archive command to generate a top level dir

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -163,7 +163,7 @@ jobs:
           chmod +x "${PLATFORM_DIR}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
-          tar -czv ${PLATFORM_DIR} -f "$PACKAGE_FILENAME"
+          tar -czvf "$PACKAGE_FILENAME" "${PLATFORM_DIR}"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact


### PR DESCRIPTION
Followup of https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/pull/2/commits/be6543a5d8c6d0a9376f4c3a0c353e9d890184f0