### PR TITLE
Refactor variables in release workflows

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os:
+        task:
           - Windows_32bit
           - Windows_64bit
           - Linux_32bit
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -57,7 +57,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -67,7 +67,7 @@ jobs:
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
-    name: Notarize ${{ matrix.artifact.name }}
+    name: Notarize ${{ matrix.build.folder-suffix }}
     runs-on: macos-latest
     needs: create-release-artifacts
     outputs:
@@ -81,11 +81,11 @@ jobs:
 
     strategy:
       matrix:
-        artifact:
-          - name: darwin_amd64
-            path: "macOS_64bit.tar.gz"
-          - name: darwin_arm64
-            path: "macOS_ARM64.tar.gz"
+        build:
+          - folder-suffix: darwin_amd64
+            package-suffix: "macOS_64bit.tar.gz"
+          - folder-suffix: darwin_arm64
+            package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
       - name: Checkout repository
@@ -131,7 +131,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -160,10 +160,10 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          PLATFORM_DIR="${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}"
+          PLATFORM_DIR="${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}"
           chmod +x "${PLATFORM_DIR}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
+          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" "${PLATFORM_DIR}"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -92,6 +92,8 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -166,10 +168,7 @@ jobs:
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
-          tar -czvf "$PACKAGE_FILENAME" "${PLATFORM_DIR}"
-          echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
+          tar -czvf "${{ env.PACKAGE_FILENAME }}" \
           -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
 
       - name: Upload artifact

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -88,6 +88,11 @@ jobs:
             package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -131,7 +136,7 @@ jobs:
         run: |
           cat > "${{ env.GON_CONFIG_PATH }}" <<EOF
           # See: https://github.com/Bearer/gon#configuration-file
-          source = ["${{ env.DIST_DIR }}/${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}/${{ env.PROJECT_NAME }}"]
+          source = ["${{ env.DIST_DIR }}/${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"]
           bundle_id = "cc.arduino.${{ env.PROJECT_NAME }}"
 
           sign {
@@ -160,12 +165,12 @@ jobs:
         run: |
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
-          PLATFORM_DIR="${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}"
-          chmod +x "${PLATFORM_DIR}/${{ env.PROJECT_NAME }}"
+          chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
           tar -czvf "$PACKAGE_FILENAME" "${PLATFORM_DIR}"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
+          -C "${{ env.BUILD_FOLDER }}/" "${{ env.PROJECT_NAME }}" \
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
A GitHub Actions workflows is used to automatically generate production builds of the project.

While starting the work to update the workflow code for compatibility with the breaking change introduced in the latest versions of the **actions/upload-artifact** action (https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/pull/27), I found that it was quite difficult to follow the workflow code due to the way some variables were defined. The refactoring proposed here is intended to improve the maintainability and readability of the workflows:

## Use more meaningful variable names

A separate build is generated for each of the target host types. This is done using a job matrix, which creates a parallel run of the workflow job for each target. The matrix defines variables that provide the data that is specific to each job.

The variable names used previously did not clearly communicate their nature:

- The variable for the task name was named "os"
- The variables for the build filename components used the term "artifact", which is ambiguous in this context where the term is otherwise used to refer to the completely unrelated workflow artifacts

These variable names made it very difficult for anyone not intimately familiar with the workings of the workflow to understand its code.

## Use workflow environment variables to reduce code duplication

Multiple commands in the notarization step of the "Release" workflow include the path of the folder that contains the build output, and the filename of the package.

Previously, there was some code duplication and inconsistency in how these were referenced.

This is improved on through the consistent use of workflow environment variables.
