### PR TITLE
Move definition of package filename to dedicated step in release workflow

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -92,6 +92,8 @@ jobs:
         run: |
           # See: https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-environment-variable
           echo "BUILD_FOLDER=${{ env.PROJECT_NAME }}_osx_${{ matrix.build.folder-suffix }}" >> "$GITHUB_ENV"
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          echo "PACKAGE_FILENAME=${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -166,10 +168,7 @@ jobs:
           # GitHub's upload/download-artifact actions don't preserve file permissions,
           # so we need to add execution permission back until the action is made to do this.
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
-          TAG="${GITHUB_REF/refs\/tags\//}"
-          PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.build.package-suffix }}"
-          tar -czvf "$PACKAGE_FILENAME" "${{ env.BUILD_FOLDER }}"
-          echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
+          tar -czvf "${{ env.PACKAGE_FILENAME }}" "${{ env.BUILD_FOLDER }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The package filename is referenced in multiple places in the release workflow. In order to avoid code duplication, it is defined once as an environment variable, then that variable referenced in each of the instances where the filename is needed.

Previously, this was done by first defining and referencing a shell environment variable at the point of the first usage, then defining a workflow environment variable and referencing that in the second usage.

The maintainability and readability of the workflow is improved by using a single workflow environment variable, defined in the step dedicated to defining such variables, then referencing it consistently in all usages.