### PR TITLE
Remove unused job outputs from release workflow

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -70,9 +70,6 @@ jobs:
     name: Notarize ${{ matrix.build.folder-suffix }}
     runs-on: macos-latest
     needs: create-release-artifacts
-    outputs:
-      checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
-      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
     permissions:
       contents: read
 
@@ -161,7 +158,6 @@ jobs:
           gon "${{ env.GON_CONFIG_PATH }}"
 
       - name: Re-package binary
-        id: re-package
         working-directory: ${{ env.DIST_DIR }}
         # Repackage the signed binary replaced in place by Gon (ignoring the output zip file)
         run: |


### PR DESCRIPTION
In a previous revision of the release workflow, the updated checksums were determined by the macOS notarization job and then passed to the subsequent job via job outputs. That approach was changed during a later refactoring, but the code that declares the job outputs was not removed at that time.

The checksum job output declaration code is now unused (and unusable since the checksum determination and output definitions were removed) so it only makes the workflows more difficult to understand and maintain. For this reason, the vestigial code is hereby removed from the workflow.