### PR TITLE
Don't upload multiple times to same artifact in label sync workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   CONFIGURATIONS_FOLDER: .github/label-configuration-files
-  CONFIGURATIONS_ARTIFACT: label-configuration-files
+  CONFIGURATIONS_ARTIFACT_PREFIX: label-configuration-file-
 
 jobs:
   check:
@@ -80,7 +80,7 @@ jobs:
             *.yaml
             *.yml
           if-no-files-found: error
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}${{ matrix.filename }}
 
   sync:
     needs: download
@@ -114,16 +114,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download configuration files artifact
+      - name: Download configuration file artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          merge-multiple: true
+          pattern: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}*
           path: ${{ env.CONFIGURATIONS_FOLDER }}
 
-      - name: Remove unneeded artifact
+      - name: Remove unneeded artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: ${{ env.CONFIGURATIONS_ARTIFACT }}
+          name: ${{ env.CONFIGURATIONS_ARTIFACT_PREFIX }}*
 
       - name: Merge label configuration files
         run: |


### PR DESCRIPTION
The "Sync Labels" GitHub Actions workflow is configured to allow the use of multiple shared label configuration files. This is done by using a job matrix in the GitHub Actions workflow to download each of the files from the source repository in a parallel GitHub Actions workflow job. A GitHub Actions workflow artifact was used to transfer the generated files between sequential jobs in the workflow. The "actions/upload-artifact" and "actions/download-artifact" actions are used for this purpose.

Previously, a single artifact was used for the transfer of all the shared label configuration files, with each of the parallel jobs uploading its own generated files to that artifact. However, support for uploading multiple times to a single artifact was dropped in version 4.0.0 of the "actions/upload-artifact" action (https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/pull/27). So it is now necessary to use a dedicated artifact for each of the builds. These can be downloaded in aggregate by using the artifact name globbing and merging features which were introduced in version 4.1.0 of the "actions/download-artifact" action.