### PR TITLE
Don't upload multiple times to same artifact in release workflow

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -8,7 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /arduino-fwuploader/plugins/
-  ARTIFACT_NAME: dist
+  ARTIFACT_PREFIX: dist-
 
 on:
   push:
@@ -23,16 +23,25 @@ jobs:
 
     strategy:
       matrix:
-        task:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+        os:
+          - task: Windows_32bit
+            artifact-suffix: Windows_32bit
+          - task: Windows_64bit
+            artifact-suffix: Windows_64bit
+          - task: Linux_32bit
+            artifact-suffix: Linux_32bit
+          - task: Linux_64bit
+            artifact-suffix: Linux_64bit
+          - task: Linux_ARMv6
+            artifact-suffix: Linux_ARMv6
+          - task: Linux_ARMv7
+            artifact-suffix: Linux_ARMv7
+          - task: Linux_ARM64
+            artifact-suffix: Linux_ARM64
+          - task: macOS_64bit
+            artifact-suffix: macOS_64bit
+          - task: macOS_ARM64
+            artifact-suffix: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -42,7 +51,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.task == 'Windows_32bit'
+        if: matrix.os.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -57,13 +66,13 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.task }}
+        run: task dist:${{ matrix.os.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.os.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
   notarize-macos:
@@ -79,9 +88,11 @@ jobs:
     strategy:
       matrix:
         build:
-          - folder-suffix: darwin_amd64
+          - artifact-suffix: macOS_64bit
+            folder-suffix: darwin_amd64
             package-suffix: "macOS_64bit.tar.gz"
-          - folder-suffix: darwin_arm64
+          - artifact-suffix: macOS_ARM64
+            folder-suffix: darwin_arm64
             package-suffix: "macOS_ARM64.tar.gz"
 
     steps:
@@ -98,7 +109,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
       - name: Import Code-Signing Certificates
@@ -166,11 +177,12 @@ jobs:
           chmod +x "${{ env.BUILD_FOLDER }}/${{ env.PROJECT_NAME }}"
           tar -czvf "${{ env.PACKAGE_FILENAME }}" "${{ env.BUILD_FOLDER }}"
 
-      - name: Upload artifact
+      - name: Replace artifact with notarized build
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.build.artifact-suffix }}
+          overwrite: true
           path: ${{ env.DIST_DIR }}/${{ env.PACKAGE_FILENAME }}
 
   create-release:
@@ -186,7 +198,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
 
       - name: Install Taskfile


### PR DESCRIPTION
The release workflow produces binaries for a range of target hosts. This is done by using a job matrix in the GitHub Actions workflow that produces each build in a parallel job. GitHub Actions workflow artifacts are used to transfer the generated files between sequential jobs in the workflow. The "actions/upload-artifact" action is used for this purpose.

Previously, a single artifact was used for this purpose, with each of the parallel jobs uploading its own generated files to that artifact. However, support for uploading multiple times to a single artifact was dropped in version 4.0.0 of the "actions/upload-artifact" action (https://github.com/arduino/uno-r4-wifi-fwuploader-plugin/pull/27). So it is now necessary to use a dedicated artifact for each of the builds. These can be downloaded in aggregate by using the artifact name globbing and merging features which were introduced in version 4.1.0 of the "actions/download-artifact" action.