### PR TITLE
Bump project Node.js version to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "markdownlint-cli": "^0.48.0"
       },
       "engines": {
-        "node": "16.x"
+        "node": "24.x"
       }
     },
     "node_modules/@types/debug": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "markdownlint-cli": "^0.48.0"
   },
   "engines": {
-    "node": "16.x"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
npm package-based tools are used for various development and maintenance operations for this project. In order to ensure
these operations work as expected, the project is configured for a specific major version of Node.js to be used by the
project infrastructure and collaborators.

The standard Node.js version for Arduino Tooling projects is now 24.